### PR TITLE
fix: strictly compare payload with undefined in actionType

### DIFF
--- a/src/createAction.ts
+++ b/src/createAction.ts
@@ -11,7 +11,7 @@ function createAction<T>(actionType: string): IActionCreator<T> {
   }
   return function actionCreator(payload?: T): IAction<T> {
     const action: IAction<T> = { type: actionType };
-    if (payload != null) {
+    if (payload !== undefined) {
       action.payload = payload;
     }
     return action;


### PR DESCRIPTION
Thanks for your fixing my previous PR. But there is a small flaw in `actionType`, which can raise confusion in the situation where `actionType` accepts no parameter or just a `null`. After all, `actionType()` is not same as `actionType(null)` - `null` makes sense sometimes.

(The `yarn run test / lint / build` have been run and thrown no error.) 
